### PR TITLE
Extensions to integration

### DIFF
--- a/custom_components/bwt_perla/api.py
+++ b/custom_components/bwt_perla/api.py
@@ -2,6 +2,7 @@ import logging
 
 import requests
 import urllib3
+from bs4 import BeautifulSoup
 
 from .const import DOMAIN
 
@@ -50,10 +51,110 @@ class BWTPerlaApi:
         _LOGGER.debug(f"{DOMAIN} - actualizesignals response {response.text}")
         signal_response: dict = response.json()
 
+        # regeneratingagent request
+        url = self.base_url + "info/regeneratingagent"
+        response = session.post(url, headers=self.headers, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - regeneratingagent response {response.text}")
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find_all("span", class_="subMenuValue")
+        keys = ['regeneratingagent_commissioning', 'regeneratingagent_maintenance', 'regeneratingagent_refill', 'regenerations_total', 'regenerations_maintenance']
+        values = []
+        for result in results:
+            values.append(result.text.split(" ")[0])
+        regeneratingagent_response = dict(zip(keys, values))
+        
         # logout
         url = self.base_url + "users/logout"
         response = session.get(url, verify=False)
 
-        merged_response = data_response | signal_response
+        merged_response = data_response | signal_response | regeneratingagent_response
         _LOGGER.debug(f"{DOMAIN} - merged_response {merged_response}")
         return merged_response
+
+    def get_warnings(self) -> dict:
+        # create a session with login page
+        url = self.base_url + "users/login"
+        session = requests.Session()
+        response = session.get(url, verify=False)
+
+        # login with password
+        url = self.base_url + "users/login"
+        data = {"_method": "POST", "STLoginPWField": self.code, "function": "save"}
+        response = session.post(url, headers=self.headers, data=data, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - login response {response.text}")
+
+        # warnings request
+        url = self.base_url + "home/warnings"
+        response = session.post(url, headers=self.headers, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - warnings response {response.text}")
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find_all("div", class_="notification")
+        warnings_response = {}
+        for result in results:
+            divs = result.find("div", class_="notificationLeftText").find_all("div")
+            warnings_response[result['id']] = divs[0].text+" "+divs[1].text
+            
+        # logout
+        url = self.base_url + "users/logout"
+        response = session.get(url, verify=False)
+
+        return warnings_response    
+        
+    def get_holiday_mode(self) -> bool:
+        # create a session with login page
+        url = self.base_url + "users/login"
+        session = requests.Session()
+        response = session.get(url, verify=False)
+
+        # login with password
+        url = self.base_url + "users/login"
+        data = {"_method": "POST", "STLoginPWField": self.code, "function": "save"}
+        response = session.post(url, headers=self.headers, data=data, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - login response {response.text}")
+
+        # holidaymode request
+        url = self.base_url + "functions/holidaymode"
+        response = session.post(url, headers=self.headers, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - holidaymode response {response.text}")
+        soup = BeautifulSoup(response.content, "html.parser")
+        results = soup.find(id="changeHolidaymode")
+        holidayMode = False
+        if results.has_attr('checked'):
+            holidayMode = True
+                
+        # logout
+        url = self.base_url + "users/logout"
+        response = session.get(url, verify=False)
+
+        return holidayMode    
+        
+    # Extra Regeneration auslösen --> 482, 1
+    # Extra Spülung auslösen --> 483, 1
+    # Urlaubsmodus einschalten --> 484, 1
+    # Urlaubsmodus ausschalten --> 484, 0
+    def save_value(self, id: int, value: int) -> bool:
+        # create a session with login page
+        url = self.base_url + "users/login"
+        session = requests.Session()
+        response = session.get(url, verify=False)
+
+        # login with password
+        url = self.base_url + "users/login"
+        data = {"_method": "POST", "STLoginPWField": self.code, "function": "save"}
+        response = session.post(url, headers=self.headers, data=data, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - login response {response.text}")
+
+        # set value for given id
+        url = self.base_url + "keyboard/saveValue"
+        data = {"_method": "POST", "ID": id, "Value": value}
+        response = session.post(url, headers=self.headers, data=data, verify=False)
+        _LOGGER.debug(f"{DOMAIN} - saveValue response {response.text}")
+        success = False
+        if (response.status_code == requests.codes.ok):
+            success = True   
+        
+        # logout
+        url = self.base_url + "users/logout"
+        response = session.get(url, verify=False)
+        
+        return success

--- a/custom_components/bwt_perla/manifest.json
+++ b/custom_components/bwt_perla/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [],
   "config_flow": true,
   "codeowners": ["@fuatakgun"],
-  "requirements": [],
+  "requirements": ["beautifulsoup4==4.10.0"],
   "version": "0.0.1"
 }

--- a/custom_components/bwt_perla/sensor.py
+++ b/custom_components/bwt_perla/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     PERCENTAGE,
     TIME_DAYS,
     VOLUME_LITERS,
+    MASS_KILOGRAMS,
 )
 
 from .const import DOMAIN
@@ -76,6 +77,46 @@ async def async_setup_entry(hass, entry, async_add_devices):
             "mdi:calendar-today",
             None,
         ),
+        (
+            "regeneratingagent_commissioning",
+            "Regenerating agent since commissioning",
+            "regeneratingagent_commissioning",
+            MASS_KILOGRAMS,
+            "mdi:grain",
+            None,
+        ),
+        (
+            "regeneratingagent_maintenance",
+            "Regenerating agent since maintenance",
+            "regeneratingagent_maintenance",
+            MASS_KILOGRAMS,
+            "mdi:grain",
+            None,
+        ),
+        (
+            "regeneratingagent_refill",
+            "Regenerating agent since refill",
+            "regeneratingagent_refill",
+            MASS_KILOGRAMS,
+            "mdi:grain",
+            None,
+        ),
+        (
+            "regenerations_total",
+            "Regeneratins since commissioning",
+            "regenerations_total",
+            None,
+            "mdi:refresh",
+            None,
+        ),    
+        (
+            "regenerations_maintenance",
+            "Regeneratins since maintenance",
+            "regenerations_maintenance",
+            None,
+            "mdi:refresh",
+            None,
+        ),    
     ]
 
     sensors = [

--- a/custom_components/bwt_perla/sensor.py
+++ b/custom_components/bwt_perla/sensor.py
@@ -103,7 +103,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         ),
         (
             "regenerations_total",
-            "Regeneratins since commissioning",
+            "Regenerations since commissioning",
             "regenerations_total",
             None,
             "mdi:refresh",
@@ -111,7 +111,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         ),    
         (
             "regenerations_maintenance",
-            "Regeneratins since maintenance",
+            "Regenerations since maintenance",
             "regenerations_maintenance",
             None,
             "mdi:refresh",

--- a/custom_components/bwt_perla/translations/de.json
+++ b/custom_components/bwt_perla/translations/de.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BWT Perla: Authentifizierung",
+        "description": "Bitte IP Adresse und Web UI Zugriffscode der BWT Perla eingeben",
+        "data": {
+          "host": "Host IP Adresse (z.B. 192.168.178.22)",
+          "code": "Code"
+        }
+      }
+    },
+    "error": {
+      "auth": "Host/Code ist falsch."
+    },
+    "abort": {
+      "single_instance_allowed": "Nur eine Instanz ist erlaubt."
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "title": "BWT Perla: Konfiguration",
+        "data": {
+          "sync_interval": "Synchronisierungsintervall in Sekunden um Daten zu laden"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* added additional infos regarding regeneration agent usage and number of regenerations
* added German translation
* added methods to api.py that are not used yet
  * extracting additional infos from HTML: get_warnings() + get_holiday_mode()
  * added save_value() to trigger holiday_mode, extra cleaning and extra regeneration

idea was to add the following (which proved to go beyond my python/home assistant skills):
* Switch Entity: Vacation Mode on/off --> get_holiday_mode() + save_value(484,1)/save_value(484,0)
* Button Entities: Start Extra Regeneration --> save_value(482,1) and Start Extra Cleaning --> save_value(483,1)